### PR TITLE
Reduce console errors (UNTESTED)

### DIFF
--- a/src/scripts/turnmarker.js
+++ b/src/scripts/turnmarker.js
@@ -53,9 +53,11 @@ Hooks.on('createTile', (scene, tile) => {
 
 Hooks.on('preUpdateToken', async (scene, token) => {
     if (game.combat) {
-        if (token._id == game.combat.combatant.token._id && !canvas.scene.getFlag(FlagScope, Flags.startMarkerPlaced)) {
-            await Marker.placeStartMarker(game.combat.combatant.token._id);
-        }
+        try {
+            if (token._id == game.combat.combatant.token._id && !canvas.scene.getFlag(FlagScope, Flags.startMarkerPlaced)) {
+                await Marker.placeStartMarker(game.combat.combatant.token._id);
+            }
+        } catch (err) {} // silence errors that originate from moving tokens when there is no ongoing combat
     }
 });
 


### PR DESCRIPTION
I'm getting errors in the console that aren't actually problems. This should silence the errors.

<details><summary>Errors:</summary>
<p>

```
turnmarker.js:56 Uncaught (in promise) TypeError: Cannot read property 'token' of undefined
    at turnmarker.js:56
    at Function._call (foundry.js:2239)
    at Function.call [as __furnace_original_call] (foundry.js:2224)
    at Function.callOriginalFunction (Patches.js:57)
    at Function.<anonymous> (Debug.js:42)
    at foundry.js:10265
    at Array.reduce (<anonymous>)
    at Scene.updateEmbeddedEntity (foundry.js:10253)
    at Token.update (foundry.js:12053)
    at DragRuler.moveToken (showdragdistance.js:323)
```

</p>
</details>

Fixes #12 