### PR TITLE
Nullpointer when game.combat is not null but game.combat.combatant == null

### DIFF
--- a/src/scripts/turnmarker.js
+++ b/src/scripts/turnmarker.js
@@ -52,7 +52,7 @@ Hooks.on('createTile', (scene, tile) => {
 });
 
 Hooks.on('preUpdateToken', async (scene, token) => {
-    if (game.combat) {
+    if (game.combat != null && game.combat.turn != -1) {
         if (token._id == game.combat.combatant.token._id && !canvas.scene.getFlag(FlagScope, Flags.startMarkerPlaced)) {
             await Marker.placeStartMarker(game.combat.combatant.token._id);
         }


### PR DESCRIPTION
This bug appeared randomly while swapping scenes, very noise. I end-up fixing the bug before thinking of taking a screenshot to submit this PR. Your call, reach me on Discord if needed Engrenado#2576