### PR TITLE
Label with FVTT v0.6.6 compatability

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -5,7 +5,7 @@
 	"author": "Brunhine",
 	"version": "2.6.9",
 	"minimumCoreVersion": "0.5.6",
-	"compatibleCoreVersion": "0.6.2",
+	"compatibleCoreVersion": "0.6.6",
 	"esmodules": [
 		"scripts/turnmarker.js"
 	],


### PR DESCRIPTION
I've been using TurnMarker with FVTT v0.6.6 for some time an experienced no issues that aren't already filed here and present with earlier FVTT versions. This PR updates the compatible version list so FVTT stops flagging TurnMarker with the "Compatibility Risk" label in the module management UI.